### PR TITLE
Add python3.11 and lower support

### DIFF
--- a/hueforge/color/detection.py
+++ b/hueforge/color/detection.py
@@ -15,4 +15,4 @@ class Detection:
         elif isinstance(value, str) and value.replace(' ', '').lower().isidentifier():
             return 'direct'
 
-        raise ValueError(f'Invalid value with unknown format: {value}. Possible formats: {['hex', 'hexa', 'rgb', 'rgba', 'direct']}')  # noqa
+        raise ValueError(f'Invalid value with unknown format: {value}. Possible formats: {["hex", "hexa", "rgb", "rgba", "direct"]}')  # noqa


### PR DESCRIPTION
Python version 3.11 and lower does not allow nesting of string literals with the same quote type inside f-strings.